### PR TITLE
Unlock min_zoom level to 100m

### DIFF
--- a/src/Input/InputEventsMap.cpp
+++ b/src/Input/InputEventsMap.cpp
@@ -206,15 +206,9 @@ InputEvents::sub_SetZoom(double value)
     Message::AddMessage(_("Auto. zoom off"));
   }
 
-  auto vmin = CommonInterface::GetComputerSettings().polar.glide_polar_task.GetVMin();
-  auto scale_2min_distance = vmin * 12;
   const double scale_100m = 10;
   const double scale_1600km = 1600*100;
-  auto minreasonable = displayMode == DisplayMode::CIRCLING
-    ? scale_100m
-    : std::max(scale_100m, scale_2min_distance);
-
-  value = Clamp(value, minreasonable, scale_1600km);
+  value = Clamp(value, scale_100m, scale_1600km);
   map_window->SetMapScale(value);
   map_window->QuickRedraw();
 }


### PR DESCRIPTION
This is useful especially for paraglider.
I think it's better to let user decide which zoom level they want instead of hard limited based on their polar