### PR TITLE
Update hardcoded climb mode threshold value

### DIFF
--- a/src/Computer/CirclingComputer.cpp
+++ b/src/Computer/CirclingComputer.cpp
@@ -29,8 +29,8 @@ Copyright_License {
 #include "Math/LowPassFilter.hpp"
 #include "util/Clamp.hpp"
 
-static constexpr Angle MIN_TURN_RATE = Angle::Degrees(4);
-static constexpr double CRUISE_CLIMB_SWITCH(15);
+static constexpr Angle MIN_TURN_RATE = Angle::Degrees(10);
+static constexpr double CRUISE_CLIMB_SWITCH(5);
 static constexpr double CLIMB_CRUISE_SWITCH(10);
 
 void


### PR DESCRIPTION
Current value is a bit too long for paragliding flight, so change the hardcoded value here.

We could possibly move these hardcode number to the setting page.