### PR TITLE
Clear JETProvider data when config changes

### DIFF
--- a/src/ProcessTimer.cpp
+++ b/src/ProcessTimer.cpp
@@ -279,6 +279,7 @@ ProcessTimer() noexcept
 #ifdef HAVE_TRACKING
     if (net_components->tracking) {
       net_components->tracking->SetSettings(CommonInterface::GetComputerSettings().tracking);
+      net_components->tracking->SetJETSettings(CommonInterface::GetComputerSettings().jet_provider_setting);
       net_components->tracking->OnTimer(CommonInterface::Basic(), CommonInterface::Calculated());
     }
 #endif

--- a/src/Tracking/JETProvider/Settings.hpp
+++ b/src/Tracking/JETProvider/Settings.hpp
@@ -39,12 +39,22 @@ struct JETProviderSettings {
       interval = std::chrono::seconds(5);
       access_token.clear();
     }
+
+    bool operator!=(const Radar &other) const {
+      return enabled != other.enabled ||
+             interval != other.interval ||
+             access_token != other.access_token;
+    }
   };
 
   Radar radar;
 
   void SetDefaults() {
     radar.SetDefaults();
+  }
+
+  bool operator!=(const JETProviderSettings &other) const {
+    return radar != other.radar;
   }
 };
 

--- a/src/Tracking/TrackingGlue.cpp
+++ b/src/Tracking/TrackingGlue.cpp
@@ -24,6 +24,15 @@ TrackingGlue::SetSettings(const TrackingSettings &_settings)
 }
 
 void
+TrackingGlue::SetJETSettings(const JETProviderSettings &_settings)
+{
+  if (jet_provider_settings != _settings) {
+    jet_provider_settings = _settings;
+    OnJETProviderReset();
+  }
+}
+
+void
 TrackingGlue::OnTimer(const MoreData &basic, const DerivedInfo &calculated)
 {
   try {

--- a/src/Tracking/TrackingGlue.hpp
+++ b/src/Tracking/TrackingGlue.hpp
@@ -36,6 +36,11 @@ class TrackingGlue final
   JETProvider::Glue jet_provider;
   
   JETProvider::Data jet_provider_data;
+
+  /**
+   * Stored copy of the settings used to detect changes
+   * and reset the JETProvider data accordingly.
+   */
   JETProviderSettings jet_provider_settings;
 
   /**

--- a/src/Tracking/TrackingGlue.hpp
+++ b/src/Tracking/TrackingGlue.hpp
@@ -12,6 +12,7 @@
 #include "Tracking/SkyLines/Data.hpp"
 #include "Tracking/LiveTrack24/Glue.hpp"
 #include "Tracking/JETProvider/JETProvider.hpp"
+#include "Tracking/JETProvider/Settings.hpp"
 #include "thread/StandbyThread.hpp"
 #include "time/PeriodClock.hpp"
 #include "Geo/GeoPoint.hpp"
@@ -35,6 +36,7 @@ class TrackingGlue final
   JETProvider::Glue jet_provider;
   
   JETProvider::Data jet_provider_data;
+  JETProviderSettings jet_provider_settings;
 
   /**
    * The Unix UTC time stamp that was last submitted to the tracking
@@ -53,6 +55,7 @@ public:
   TrackingGlue(EventLoop &event_loop, CurlGlobal &curl) noexcept;
 
   void SetSettings(const TrackingSettings &_settings);
+  void SetJETSettings(const JETProviderSettings &_settings);
 
   void OnTimer(const MoreData &basic, const DerivedInfo &calculated);
 


### PR DESCRIPTION
- Added `operator!=` to `JETProviderSettings`
- Stored `JETProviderSettings` copy in `TrackingGlue`
- Called `OnJETProviderReset()` inside `TrackingGlue::SetJETSettings` when `JETProviderSettings` changes
- Called `SetJETSettings()` in `ProcessTimer.cpp` with `CommonInterface::GetComputerSettings().jet_provider_setting`

---
*PR created automatically by Jules for task [1613257973242345858](https://jules.google.com/task/1613257973242345858) started by @zinuzoid*